### PR TITLE
修改css和js的CDN源,修复UI组件库失效的问题

### DIFF
--- a/v2.beta.html
+++ b/v2.beta.html
@@ -8,7 +8,7 @@
     <meta name="force-rendering" content="webkit" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <!-- MDUI CSS -->
-    <link rel="stylesheet" href="https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/mdui/1.0.2/css/mdui.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/mdui@1.0.2/dist/css/mdui.min.css" />
     <title>VideoTogether</title>
 </head>
 
@@ -433,7 +433,7 @@
 
     </script>
     <!-- MDUI JavaScript -->
-    <script src="https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/mdui/1.0.2/js/mdui.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/mdui@1.0.2/dist/js/mdui.min.js"></script>
     <style>
         .mdui-card {
             border-radius: 12px;

--- a/v2.buildme.html
+++ b/v2.buildme.html
@@ -8,7 +8,7 @@
     <meta name="force-rendering" content="webkit" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <!-- MDUI CSS -->
-    <link rel="stylesheet" href="https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/mdui/1.0.2/css/mdui.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/mdui@1.0.2/dist/css/mdui.min.css" />
     <title>VideoTogether</title>
 </head>
 
@@ -499,7 +499,7 @@
         }
     </script>
     <!-- MDUI JavaScript -->
-    <script src="https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/mdui/1.0.2/js/mdui.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/mdui@1.0.2/dist/js/mdui.min.js"></script>
     <style>
         .mdui-card {
             border-radius: 12px;

--- a/v2.html
+++ b/v2.html
@@ -8,7 +8,7 @@
     <meta name="force-rendering" content="webkit" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <!-- MDUI CSS -->
-    <link rel="stylesheet" href="https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/mdui/1.0.2/css/mdui.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/mdui@1.0.2/dist/css/mdui.min.css" />
     <title>VideoTogether</title>
 </head>
 
@@ -573,7 +573,7 @@
         }
     </script>
     <!-- MDUI JavaScript -->
-    <script src="https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/mdui/1.0.2/js/mdui.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/mdui@1.0.2/dist/js/mdui.min.js"></script>
     <style>
         .mdui-card {
             border-radius: 12px;

--- a/v2_website.html
+++ b/v2_website.html
@@ -8,7 +8,7 @@
     <meta name="force-rendering" content="webkit" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <!-- MDUI CSS -->
-    <link rel="stylesheet" href="https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/mdui/1.0.2/css/mdui.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/mdui@1.0.2/dist/css/mdui.min.css" />
     <title>VideoTogether</title>
 </head>
 
@@ -292,7 +292,7 @@
         </div>
     </div>
     <!-- MDUI JavaScript -->
-    <script src="https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/mdui/1.0.2/js/mdui.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/mdui@1.0.2/dist/js/mdui.min.js"></script>
     <style>
         .mdui-card {
             border-radius: 12px;


### PR DESCRIPTION
将 mdui 库的 CDN 源改成 jsdelivr，源 CDN 好像已经失效了